### PR TITLE
use correct framework

### DIFF
--- a/Source/SuperOffice.DevNet.OpenIDConnectNativeApp/SuperOffice.DevNet.OpenIDConnectNativeApp.csproj
+++ b/Source/SuperOffice.DevNet.OpenIDConnectNativeApp/SuperOffice.DevNet.OpenIDConnectNativeApp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net80</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>SuperOffice.DevNet.OpenIDConnectNativeApp</RootNamespace>
     <AssemblyName>SuperOffice.DevNet.OpenIDConnectNativeApp</AssemblyName>
   </PropertyGroup>

--- a/Source/SuperOffice.DevNet.WebApiClient.Oidc/SuperOffice.DevNet.WebApiClient.Oidc.csproj
+++ b/Source/SuperOffice.DevNet.WebApiClient.Oidc/SuperOffice.DevNet.WebApiClient.Oidc.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net80</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>SuperOffice.DevNet.WebApiClient.Oidc</AssemblyName>
     <RootNamespace>SuperOffice.DevNet.WebApiClient.Oidc</RootNamespace>
   </PropertyGroup>


### PR DESCRIPTION
the undocumented names (without period in dotnet 5+) can drop their support when move to double-digit (to avoid potential conflicts) [learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks](https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks)